### PR TITLE
[BE] feat: 주문 등록,조회 로직 작성

### DIFF
--- a/backend/src/main/java/com/gridsandcircles/domain/order/order/controller/OrderController.java
+++ b/backend/src/main/java/com/gridsandcircles/domain/order/order/controller/OrderController.java
@@ -1,5 +1,6 @@
 package com.gridsandcircles.domain.order.order.controller;
 
+import com.gridsandcircles.domain.order.order.dto.OrderRequestDto;
 import com.gridsandcircles.domain.order.order.dto.OrderResponseDto;
 import com.gridsandcircles.domain.order.order.entity.Order;
 import com.gridsandcircles.domain.order.order.mapper.OrderMapper;
@@ -30,6 +31,24 @@ public class OrderController {
                 .toList();
 
         return ResponseEntity.ok().body(new ResultResponse<>("Get order successful", items));
+    }
+
+    @PostMapping("/{num}")
+    public ResponseEntity<ResultResponse<OrderResponseDto>> createOrder(
+            @PathVariable int num,
+            @RequestBody OrderRequestDto requestDto
+    ) {
+        OrderResponseDto responseDto = orderService.createOrder(requestDto);
+        return ResponseEntity.ok(new ResultResponse<>("Order created successfully", responseDto));
+    }
+
+    @GetMapping(params = "email")
+    public ResponseEntity<ResultResponse<List<OrderResponseDto>>> getOrdersByEmail(@RequestParam String email) {
+        List<OrderResponseDto> orders = orderService.getOrdersByEmail(email)
+                .stream()
+                .map(OrderMapper::toResponseDto)
+                .toList();
+        return ResponseEntity.ok(new ResultResponse<>("Get orders by email successful", orders));
     }
 
     @DeleteMapping("/{id}")

--- a/backend/src/main/java/com/gridsandcircles/domain/order/order/repository/OrderRepository.java
+++ b/backend/src/main/java/com/gridsandcircles/domain/order/order/repository/OrderRepository.java
@@ -3,5 +3,8 @@ package com.gridsandcircles.domain.order.order.repository;
 import com.gridsandcircles.domain.order.order.entity.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface OrderRepository extends JpaRepository<Order, Integer> {
+    List<Order> findByEmail(String email);
 }

--- a/backend/src/main/java/com/gridsandcircles/domain/product/product/service/ProductService.java
+++ b/backend/src/main/java/com/gridsandcircles/domain/product/product/service/ProductService.java
@@ -2,7 +2,9 @@ package com.gridsandcircles.domain.product.product.service;
 
 import com.gridsandcircles.domain.product.product.entity.Product;
 import com.gridsandcircles.domain.product.product.repository.ProductRepository;
+import com.gridsandcircles.global.ServiceException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -14,5 +16,10 @@ public class ProductService {
         public Product createProduct(Product product){
         productRepository.save(product);
         return product;
+    }
+
+    public Product getProductById(Long id) {
+        return productRepository.findById(id.intValue())
+                .orElseThrow(() -> new ServiceException(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."));
     }
 }

--- a/backend/src/main/java/com/gridsandcircles/global/initData/BaseInitData.java
+++ b/backend/src/main/java/com/gridsandcircles/global/initData/BaseInitData.java
@@ -1,9 +1,7 @@
 package com.gridsandcircles.global.initData;
 
-import com.gridsandcircles.domain.order.order.entity.Order;
+import com.gridsandcircles.domain.order.order.dto.OrderRequestDto;
 import com.gridsandcircles.domain.order.order.service.OrderService;
-import com.gridsandcircles.domain.order.orderitem.entity.OrderItem;
-import com.gridsandcircles.domain.order.orderitem.service.OrderItemService;
 import com.gridsandcircles.domain.product.product.entity.Product;
 import com.gridsandcircles.domain.product.product.service.ProductService;
 import jakarta.annotation.PostConstruct;
@@ -11,13 +9,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @RequiredArgsConstructor
 @Transactional
 @Configuration
 public class BaseInitData {
 
   private final OrderService orderService;
-  private final OrderItemService orderItemService;
   private final ProductService productService;
 
   @PostConstruct
@@ -25,62 +24,39 @@ public class BaseInitData {
     System.out.println("BaseInitData 초기 데이터 입력");
 
     if (orderService.countOrders() == 0) {
-      Order order1 = Order.builder()
-              .email("order1@example.com")
-              .address("서울")
-              .orderStatus(true)
-              .deliveryStatus(false)
-              .build();
-
-      Order order2 = Order.builder()
-              .email("order2@example.com")
-              .address("부산")
-              .orderStatus(true)
-              .deliveryStatus(false)
-              .build();
-
-      Product product1 = Product.builder()
+      Product product1 = productService.createProduct(Product.builder()
               .name("아메리카노")
               .price(3000)
               .description("진한 커피")
               .productImage("image.jpg1")
-              .build();
+              .build());
 
-      Product product2 = Product.builder()
+      Product product2 = productService.createProduct(Product.builder()
               .name("초코라떼")
               .price(5000)
               .description("진한 라떼")
               .productImage("image.jpg2")
-              .build();
+              .build());
 
-      OrderItem orderItem1 = OrderItem.builder()
-              .order(order1)
-              .product(product1)
-              .orderCount(10)
-              .orderItemStatus(true)
-              .build();
+      OrderRequestDto orderRequest1 = new OrderRequestDto(
+              "order1@example.com",
+              "서울",
+              List.of(
+                      new OrderRequestDto.OrderItemRequestDto(product1.getProductId().longValue(), 10),
+                      new OrderRequestDto.OrderItemRequestDto(product2.getProductId().longValue(), 20)
+              )
+      );
 
-      OrderItem orderItem2 = OrderItem.builder()
-              .order(order1)
-              .product(product2)
-              .orderCount(20)
-              .orderItemStatus(true)
-              .build();
+      OrderRequestDto orderRequest2 = new OrderRequestDto(
+              "order2@example.com",
+              "부산",
+              List.of(
+                      new OrderRequestDto.OrderItemRequestDto(product2.getProductId().longValue(), 30)
+              )
+      );
 
-      OrderItem orderItem3 = OrderItem.builder()
-              .order(order2)
-              .product(product2)
-              .orderCount(30)
-              .orderItemStatus(true)
-              .build();
-
-      orderService.createOrder(order1);
-      orderService.createOrder(order2);
-      productService.createProduct(product1);
-      productService.createProduct(product2);
-      orderItemService.createOrderItem(orderItem1);
-      orderItemService.createOrderItem(orderItem2);
-      orderItemService.createOrderItem(orderItem3);
+      orderService.createOrder(orderRequest1);
+      orderService.createOrder(orderRequest2);
 
       System.out.println("주문개수:" + orderService.countOrders());
       System.out.println("Order 엔티티 데이터 초기화");


### PR DESCRIPTION
OrderRepository에
- findByEmail()
이메일로 주문 목록 조회하기 위해 추가

OrderService에
- createOrder()
주문 등록을 위해 추가
- getOrdersByEmail()
특정 이메일의 주문 내역을 조회하기 위해 추가

ProductService에
- getProductById()
프론트에서 주문 등록 POST 요청 시, productId만 보내는데, orderItem 엔티티에 저장할 땐 해당 상품의 전체 정보가 필요해서 추가한 메서드

OrderController에
- createOrder()
프론트의 주문 등록 POST 요청을 처리
- getOrdersByEmail()
프론트의 이메일로 주문 조회 GET 요청을 처리